### PR TITLE
Do not start state if in manual mode

### DIFF
--- a/src/main/java/frc/robot/commands/indexer/IndexerAtSensorState.java
+++ b/src/main/java/frc/robot/commands/indexer/IndexerAtSensorState.java
@@ -4,7 +4,6 @@
 
 package frc.robot.commands.indexer;
 
-
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.Constants;
 import frc.robot.subsystems.Indexer;
@@ -54,12 +53,14 @@ public class IndexerAtSensorState extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return System.currentTimeMillis()-startTime >= Constants.INDEXER_AT_SENSOR_TIME_ADJUSTMENT_MS;
+    return System.currentTimeMillis() - startTime >= Constants.INDEXER_AT_SENSOR_TIME_ADJUSTMENT_MS;
   }
 
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    IndexerReadyToShootState.getInstance(this.indexer).schedule();
+    if (!this.indexer.isManualMode()) {
+      IndexerReadyToShootState.getInstance(this.indexer).schedule();
+    }
   }
 }

--- a/src/main/java/frc/robot/commands/indexer/IndexerEmptyState.java
+++ b/src/main/java/frc/robot/commands/indexer/IndexerEmptyState.java
@@ -53,6 +53,8 @@ public class IndexerEmptyState extends CommandBase {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    IndexerReceivingState.getInstance(this.indexer).schedule();
+    if (!this.indexer.isManualMode()) {
+      IndexerReceivingState.getInstance(this.indexer).schedule();
+    }
   }
 }

--- a/src/main/java/frc/robot/commands/indexer/IndexerReadyToShootState.java
+++ b/src/main/java/frc/robot/commands/indexer/IndexerReadyToShootState.java
@@ -73,6 +73,8 @@ public class IndexerReadyToShootState extends CommandBase {
    */
   @Override
   public void end(boolean interrupted) {
-    IndexerShootingState.getInstance(this.indexer).schedule();
+    if (!this.indexer.isManualMode()) {
+      IndexerShootingState.getInstance(this.indexer).schedule();
+    }
   }
 }

--- a/src/main/java/frc/robot/commands/indexer/IndexerReceivingState.java
+++ b/src/main/java/frc/robot/commands/indexer/IndexerReceivingState.java
@@ -49,7 +49,7 @@ public class IndexerReceivingState extends CommandBase {
     addRequirements(indexer);
   }
 
- /**
+  /**
    * {@inheritDoc}
    * 
    * <p>
@@ -73,8 +73,7 @@ public class IndexerReceivingState extends CommandBase {
     return this.indexer.isCargoAtSensor();
   }
 
-
- /**
+  /**
    * {@inheritDoc}
    * 
    * <p>
@@ -85,6 +84,8 @@ public class IndexerReceivingState extends CommandBase {
   @Override
   public void end(boolean interrupted) {
     this.indexer.stop();
-    IndexerAtSensorState.getInstance(this.indexer).schedule();
+    if (!this.indexer.isManualMode()) {
+      IndexerAtSensorState.getInstance(this.indexer).schedule();
+    }
   }
 }

--- a/src/main/java/frc/robot/commands/indexer/IndexerShootingState.java
+++ b/src/main/java/frc/robot/commands/indexer/IndexerShootingState.java
@@ -85,6 +85,8 @@ public class IndexerShootingState extends CommandBase {
   public void end(boolean interrupted) {
     this.indexer.stop();
     RobotCargoCount.getInstance().decrement();
-    IndexerEmptyState.getInstance(this.indexer).schedule();
+    if (!this.indexer.isManualMode()) {
+      IndexerEmptyState.getInstance(this.indexer).schedule();
+    }
   }
 }


### PR DESCRIPTION
Someone should have called me on this during the last manual mode PR where I made similar changes in the intake state command end methods.

This change will, when entering manual mode, stop a state command from scheduling another state and thus terminating manual mode.