### PR TITLE
Bridge current states from auto to teleop

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -76,6 +76,11 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {}
 
   @Override
+  public void autonomousExit() {
+    this.m_robotContainer.stashAutoExitStateCommands();
+  }
+
+  @Override
   public void teleopInit() {
     // This makes sure that the autonomous stops running when
     // teleop starts running. If you want the autonomous to
@@ -84,7 +89,7 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
-    
+    this.m_robotContainer.restartAutoExitStateCommands();
   }
 
   /** This function is called periodically during operator control. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -69,6 +69,9 @@ public class RobotContainer {
 
   private final Compressor compressor = new Compressor(Constants.PNEUMATICS_HUB_CAN_ID, PneumaticsModuleType.REVPH);
 
+  private Command intakeCommandOnAutoExit = null;
+  private Command indexerCommandOnAutoExit = null;
+
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.
    */
@@ -186,6 +189,28 @@ public class RobotContainer {
    */
   public Command getAutonomousCommand() {
     return new LeftSide2CargoNoTrajectory(driveTrain, intake, indexer, shooter);
+  }
+
+  /**
+   * To be used in conjunction with restartAutoExitStateCommands to manage the
+   * state machine transition from auto to teleop mode.
+   */
+  public void stashAutoExitStateCommands() {
+    this.intakeCommandOnAutoExit = this.intake.getCurrentCommand();
+    this.indexerCommandOnAutoExit = this.indexer.getCurrentCommand();
+  }
+
+  public void restartAutoExitStateCommands() {
+    if ((this.intakeCommandOnAutoExit != null)
+        && (this.intake.getCurrentCommand() == null)) {
+      this.intakeCommandOnAutoExit.schedule();
+    }
+    if ((this.indexerCommandOnAutoExit != null)
+        && (this.indexer.getCurrentCommand() == null)) {
+      this.indexerCommandOnAutoExit.schedule();
+    }
+    this.intakeCommandOnAutoExit = null;
+    this.indexerCommandOnAutoExit = null;
   }
 
   /**


### PR DESCRIPTION
The robot may go through a period of disabled between auto
and teleop. This could cause the state commands to be
cancelled. This change will restart them on the other side.