### PR TITLE
Adjust config, add dashboard diag and debounce err

### DIFF
--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
@@ -31,7 +32,8 @@ public class Shooter extends SubsystemBase {
 
         shooterFlywheel.configFactoryDefault();
         shooterFlywheel.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor, 0, 0);
-        shooterFlywheel.configAllowableClosedloopError(0, Constants.SHOOTER_VELOCITY_ERROR);
+        shooterFlywheel.setStatusFramePeriod(StatusFrameEnhanced.Status_13_Base_PIDF0, 20);
+        shooterFlywheel.configAllowableClosedloopError(0, Constants.SHOOTER_VELOCITY_ERROR / 2);
         shooterFlywheel.configNominalOutputForward(0);
         shooterFlywheel.configNominalOutputReverse(0);
         shooterFlywheel.configPeakOutputForward(1);


### PR DESCRIPTION
Took timings out of settings in case they were creating spurious errors.
Set the closed loop tolerance. We did not do that before.
Dashboard diagnostics and on target debounce via periodic.
Watch for debounced on target in isShooterReady.