### PR TITLE
Change to shoot when in ready to shoot state

### DIFF
--- a/src/main/java/frc/robot/triggers/ShootTrigger.java
+++ b/src/main/java/frc/robot/triggers/ShootTrigger.java
@@ -2,6 +2,7 @@ package frc.robot.triggers;
 
 import java.util.function.BooleanSupplier;
 
+import frc.robot.commands.indexer.IndexerReadyToShootState;
 import frc.robot.subsystems.Indexer;
 import frc.robot.subsystems.Shooter;
 
@@ -29,6 +30,8 @@ public class ShootTrigger extends AbstractShootTrigger {
    */
   @Override
   public boolean get() {
-    return !indexer.isManualMode() && indexer.isCargoAtSensor() && super.get();
+    return !indexer.isManualMode()
+        && indexer.getCurrentCommand() instanceof IndexerReadyToShootState
+        && super.get();
   }
 }


### PR DESCRIPTION
Was just checking cargo at sensor which caused us to try to
shoot too soon. The state machine would force the proper
state sequence thus causing the shot to not happen. The
fix is to wait until the proper state is reached. BTW, the
shoot trigger used in autonomous was already doin this
and was working fine.

BTW, this might help with some of the slippage we are seeing in the indexer too. Lets not add velco until we test with this change.