### PR TITLE
Fix compile errors and simple warnings

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,12 +5,10 @@
 package frc.robot;
 
 import java.io.File;
-import java.io.FileReader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
-import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,7 +22,6 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
@@ -33,17 +30,12 @@ import frc.robot.Constants.SHOTS;
 import frc.robot.commands.DriveWithInput;
 import frc.robot.commands.LightsUpdater;
 import frc.robot.commands.ManualTurnToTarget;
-import frc.robot.commands.ReadAngle;
 import frc.robot.commands.RumbleController;
 import frc.robot.commands.ToggleIntakeIndexerManualMode;
 import frc.robot.commands.ToggleManualEjection;
-import frc.robot.commands.auto.DriveTurnToRelativeAngle;
 import frc.robot.commands.auto.CargoRingTwoBall;
-import frc.robot.commands.auto.DriveStraightDistance;
-import frc.robot.commands.auto.LeftSide2CargoNoTrajectory;
 import frc.robot.commands.auto.OneBall;
 import frc.robot.commands.auto.PlusOneTwoBall;
-import frc.robot.commands.auto.RightSide2CargoNoTrajectory;
 import frc.robot.commands.auto.RightSide3CargoNoTrajectory;
 import frc.robot.commands.auto.recording.RecordPath;
 import frc.robot.commands.auto.recording.ReplayPath;

--- a/src/main/java/frc/robot/commands/auto/AutoModeShooter.java
+++ b/src/main/java/frc/robot/commands/auto/AutoModeShooter.java
@@ -8,7 +8,6 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.commands.indexer.IndexerReadyToShootState;
 import frc.robot.commands.indexer.IndexerShootingState;
 import frc.robot.subsystems.Indexer;
-import frc.robot.subsystems.RobotCargoCount;
 import frc.robot.subsystems.Shooter;
 
 /**

--- a/src/main/java/frc/robot/commands/auto/DriveStraightDistance.java
+++ b/src/main/java/frc/robot/commands/auto/DriveStraightDistance.java
@@ -4,7 +4,6 @@
 
 package frc.robot.commands.auto;
 
-import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.Constants;
 import frc.robot.subsystems.DriveTrain;
@@ -49,7 +48,7 @@ public class DriveStraightDistance extends CommandBase {
       turningValue = -turningValue;
     }
     double power = -Constants.DRIVE_AUTO_STRAIGHT_POWER;
-    double distSoFar = this.driveTrain.getDistance();
+    //double distSoFar = this.driveTrain.getDistance();
     
     /*
     if ((distSoFar <= this.sectionAbsInches[0])

--- a/src/main/java/frc/robot/commands/auto/recording/ReplayPath.java
+++ b/src/main/java/frc/robot/commands/auto/recording/ReplayPath.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.Constants;
 import frc.robot.subsystems.DriveTrain;
 
 public class ReplayPath extends CommandBase {
@@ -38,7 +37,7 @@ public class ReplayPath extends CommandBase {
 
         double time = this.timer.get();
         double leftSpeed = this.leftSteps.get(this.index) * (60 / this.timeStep); // Converts to RPM
-        double rightSpeed = this.rightSteps.get(this.index) * (60 / this.timeStep) // Converts to RPM
+        double rightSpeed = this.rightSteps.get(this.index) * (60 / this.timeStep); // Converts to RPM
         this.driveTrain.recordingDrive(leftSpeed, -1 * rightSpeed);
 
         if (time >= this.timeStep) {

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -9,7 +9,6 @@ import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 

--- a/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -4,9 +4,6 @@
 
 package frc.robot.subsystems;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.BooleanSupplier;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
@@ -325,7 +322,7 @@ public class DriveTrain extends SubsystemBase {
     // TODO determine and set current limit.
   }
   
-  private voud pidConfig(final SparkMaxPIDController pidController) {
+  private void pidConfig(final SparkMaxPIDController pidController) {
     pidController.setFF(0.1);
     pidController.setP(0.1);
   }

--- a/src/main/java/frc/robot/subsystems/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/Indexer.java
@@ -6,10 +6,8 @@ package frc.robot.subsystems;
 
 import java.util.function.BooleanSupplier;
 
-import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.SparkMaxPIDController;
-import com.revrobotics.CANSparkMax.ControlType;
 import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -2,7 +2,6 @@ package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.Solenoid;
-import edu.wpi.first.wpilibj.motorcontrol.Spark;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -7,7 +7,6 @@ import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.Solenoid;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.Constants.LEDMode;


### PR DESCRIPTION
There were a few compilation errors and quite a few warnings (mostly unused imports) after the last merge. This PR fixes the errors and get rid of the simple to fix warnings. I will take a look at the parameterized type warnings in a new PR.